### PR TITLE
added: pgAdmin as service in docker-compose.yaml (profile dev)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,5 +41,20 @@ services:
       POSTGRES_USER: "${POSTGRES_USER:-bot}"
       POSTGRES_PASSWORD: "${POSTGRES_PASSWORD:-bot}"
 
+  pgadmin:
+    container_name: pgadmin_container
+    image: dpage/pgadmin4
+    profiles:
+      - "dev"
+    restart: on-failure
+    environment:
+      PGADMIN_DEFAULT_EMAIL: kos.zivenko@gmail.com
+      PGADMIN_DEFAULT_PASSWORD: flash_card
+    volumes:
+      - pgadmin_data:/var/lib/pgadmin
+    ports:
+      - "5050:80"
+
 volumes:
   postgres: {}
+  pgadmin_data:


### PR DESCRIPTION
Додав ще один сервіс у компоуз-файлі з тулзою для зручної роботи з БД
Додавання цього сервісу (pgadmin) зроблено з окремим профілем dev - [почитати про це можна тут](https://docs.docker.com/compose/profiles/) - тому модель використання така:
- при локальному запуску у своєму середовищі dev всі команди docker-compose використовуються з профілем dev:
```CLI
docker-compose --profile dev rm -sf
docker-compose --profile dev create --build
docker-compose --profile dev up -d
...
```
Після цього на локальному браузері за адресою 127.0.01:5050 відкриється pgAdmin
щоб зайти - логін і пароль за замовченням в рядках 51 та 52 docker-compose.yaml
Підключення до БД (якщо ви не змінювали налаштувань для локального варіанта) - точно таке як і для БД на продакшені (але БД буде створена нова, створивши локально volumes)