### PR TITLE
added: stub for command /cancel

### DIFF
--- a/app/handlers/personal/__init__.py
+++ b/app/handlers/personal/__init__.py
@@ -6,6 +6,7 @@ from app.handlers.personal.start import register_handler_start
 from app.handlers.personal.study import register_handler_study
 from app.handlers.personal.quick_self_test import register_handler_quick_selt_test
 from app.handlers.personal.help import register_handler_help
+from app.handlers.personal.cancel import register_handler_cancel
 
 
 def register_handlers_personal(dp: Dispatcher) -> None:
@@ -16,6 +17,7 @@ def register_handlers_personal(dp: Dispatcher) -> None:
         register_handler_study,
         register_handler_quick_selt_test,
         register_handler_help,
+        register_handler_cancel,
         register_handler_start,
     )
 

--- a/app/handlers/personal/cancel.py
+++ b/app/handlers/personal/cancel.py
@@ -1,0 +1,18 @@
+from typing import Optional
+from aiogram import types, Dispatcher
+from aiogram.filters import Command
+from aiogram.fsm.context import FSMContext
+
+
+async def cmd_cancel(
+    message: types.Message, state: Optional[FSMContext] = None
+) -> None:
+    if state:
+        state_name = await state.get_state()
+    else:
+        state_name = "None"
+    await message.answer(f"There will be cancel. Your state is {state_name}")
+
+
+def register_handler_cancel(dp: Dispatcher) -> None:
+    dp.message.register(cmd_cancel, Command(commands=["cancel"]))

--- a/app/main.py
+++ b/app/main.py
@@ -19,6 +19,7 @@ async def set_default_commands() -> None:
             types.BotCommand(command="study", description="study"),
             types.BotCommand(command="selftest", description="self-test"),
             types.BotCommand(command="help", description="help"),
+            types.BotCommand(command="cancel", description="cancel"),
         ]
     )
 


### PR DESCRIPTION
Заглушка для команди /cancel з епика - [cancel command](https://github.com/starperov-net/universal_flash_cards_chatbot/issues/155) , потрібна мені в поточному завданні.